### PR TITLE
fix: do not check cli53 and aws-vault versions after installing

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,5 +9,6 @@ aws_tools_python: python2.7
 # Target for symlinked binaries
 aws_bin_dir: /usr/local/bin
 
-# Do not install aws-mfa gem by default
-aws_mfa: false
+# Do not check version by default
+cli53_check_version: false
+aws_vault_check_version: false

--- a/tasks/aws_vault.yml
+++ b/tasks/aws_vault.yml
@@ -22,7 +22,9 @@
   command: aws-vault --version
   register: aws_vault_installed_version
   changed_when: False
+  when: aws_vault_check_version
 
 - name: Linux | Check that aws-vault is not out of date
   assert:
     that: "'v{{ aws_vault_version }}' == '{{ aws_vault_installed_version.stdout }}'"
+  when: aws_vault_check_version

--- a/tasks/cli53.yml
+++ b/tasks/cli53.yml
@@ -22,7 +22,9 @@
   command: cli53 --version
   register: cli53_installed_version
   changed_when: False
+  when: cli53_check_version
 
 - name: Linux | Check that cli53 is not out of date
   assert:
     that: "'cli53 version {{ cli53_version }}' == '{{ cli53_installed_version.stdout }}'"
+  when: cli53_check_version


### PR DESCRIPTION
These version checks shouldn't be needed.

This was causing some unexpected panic errors when installing aws-vault inside Ubuntu 18.04 VM.